### PR TITLE
Bump jsonpatch version dependency

### DIFF
--- a/jsonpatch-stubs/__init__.pyi
+++ b/jsonpatch-stubs/__init__.pyi
@@ -97,7 +97,7 @@ class INDEXABLE(typing.Protocol[_K_contra, _V_co]):
 _JSON_OBJECT_KEY = str
 _JSON_OBJECT = Mapping[_JSON_OBJECT_KEY, "_JSON_VALUE"]
 _JSON_ARRAY = Sequence["_JSON_VALUE"]
-_JSON_VALUE = Union[str, complex, _JSON_OBJECT, _JSON_ARRAY, bool, None]
+_JSON_VALUE = Union[str, int, float, bool, None, _JSON_OBJECT, _JSON_ARRAY]
 _JSONPOINTER_SUPPORTED_VALUES = Union[
     _JSON_VALUE,
     Mapping[_JSON_OBJECT_KEY, "_JSONPOINTER_SUPPORTED_VALUES"],
@@ -111,11 +111,6 @@ _JSONPOINTER_SUPPORTED_ROOT_VALUES = Union[
 ]
 _JSON__LOADS = Callable[[Union[str, bytes, bytearray]], _JSON_VALUE]
 _JSON__DUMPS = Callable[[_JSON_VALUE], str]
-_T_JSONPOINTER_SUPPORTED_ROOT_VALUES = TypeVar(
-    "_T_JSONPOINTER_SUPPORTED_ROOT_VALUES",
-    Mapping[_JSON_OBJECT_KEY, "_JSONPOINTER_SUPPORTED_VALUES"],
-    Sequence["_JSONPOINTER_SUPPORTED_VALUES"],
-    INDEXABLE[_JSON_OBJECT_KEY, "_JSONPOINTER_SUPPORTED_VALUES"],
 )
 
 class JsonPatchException(Exception): ...

--- a/jsonpatch-stubs/__init__.pyi
+++ b/jsonpatch-stubs/__init__.pyi
@@ -111,7 +111,7 @@ _JSONPOINTER_SUPPORTED_ROOT_VALUES = Union[
 ]
 _JSON__LOADS = Callable[[Union[str, bytes, bytearray]], _JSON_VALUE]
 _JSON__DUMPS = Callable[[_JSON_VALUE], str]
-)
+
 
 class JsonPatchException(Exception): ...
 class InvalidJsonPatch(JsonPatchException): ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "types-jsonpatch"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 description = "Type stub for jsonpatch"
 authors = [{name = "Léo El Amri", email = "leo@superlel.me"}]
 requires-python = "~=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Typing :: Stubs Only",
 ]
 dependencies = [
-    "jsonpatch ==1.32",
+    "jsonpatch ==1.33",
     "jsonpointer",
 ]
 


### PR DESCRIPTION
[No interface changes since 1.32](https://github.com/stefankoegl/python-json-patch/compare/v1.32...v1.33#diff-d854956545635c3e4666deba294b56767320e26d941c0a618246ca1c11906150)